### PR TITLE
updating sprockets for security vulnerability

### DIFF
--- a/stash_api/Gemfile.lock
+++ b/stash_api/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/stash_datacite/Gemfile.lock
+++ b/stash_datacite/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
     sortable-table (0.1.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)

--- a/stash_engine/Gemfile.lock
+++ b/stash_engine/Gemfile.lock
@@ -278,7 +278,7 @@ GEM
     sortable-table (0.1.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)


### PR DESCRIPTION
I'm not sure this vulnerability affected us because of our Ruby version, but updated anyway.