### PR TITLE
Moving metrics to an AJAX call to prevent page timeouts and dying from COUNTER

### DIFF
--- a/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -8,8 +8,8 @@ module StashEngine
     # - pdf_meta
     include StashEngine.app.metadata_engine.constantize::LandingMixin
 
-    before_action :require_identifier, except: %i[update citations]
-    before_action :require_submitted_resource, except: %i[update citations]
+    before_action :require_identifier, except: %i[update citations metrics]
+    before_action :require_submitted_resource, except: %i[update citations metrics]
     protect_from_forgery(except: [:update])
 
     # ############################################################
@@ -58,6 +58,13 @@ module StashEngine
     end
 
     def citations
+      @identifier = Identifier.find(params[:identifier_id])
+      respond_to do |format|
+        format.js
+      end
+    end
+
+    def metrics
       @identifier = Identifier.find(params[:identifier_id])
       respond_to do |format|
         format.js

--- a/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
@@ -1,0 +1,34 @@
+<%# takes local of identifier %>
+<div class="o-metrics__metric">
+  <div class="o-metrics__group">
+    <%= image_tag 'stash_engine/icon_views.svg', class: 'o-metrics__icon', alt: '' %>
+    <!-- <span class="o-metrics__label">views</span> -->
+  </div>
+  <div class="o-metrics__number">
+    <%= identifier.counter_stat.unique_investigation_count - identifier.counter_stat.unique_request_count %> views
+  </div>
+</div>
+<div class="o-metrics__metric">
+  <div class="o-metrics__group">
+    <%= image_tag 'stash_engine/icon_downloads.svg', class: 'o-metrics__icon', alt: '' %>
+    <!-- <span class="o-metrics__label">downloads</span> -->
+  </div>
+  <div class="o-metrics__number"><%= identifier.counter_stat.unique_request_count %> downloads</div>
+</div>
+<div class="o-metrics__metric">
+  <div class="o-metrics__group">
+    <%= image_tag 'stash_engine/icon_cites.svg', class: 'o-metrics__icon', alt: '' %>
+    <!-- <span class="o-metrics__label">citations</span> -->
+  </div>
+  <div class="o-metrics__number" id="metrics_citation_count">
+    <% if identifier.counter_stat.citation_count > 0 %>
+      <%= link_to "#{identifier.counter_stat.citation_count} citations", stash_url_helpers.show_citations_path(identifier_id: identifier.id),
+                  id: 'citation_link', remote: true %>
+    <% else %>
+      <%= identifier.counter_stat.citation_count %> citations
+    <% end %>
+  </div>
+  <div class="o-metrics__number" id="metrics_citation_spinner" style="display: none;">
+    <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
+  </div>
+</div>

--- a/stash_engine/app/views/stash_engine/landing/_sidebar.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_sidebar.html.erb
@@ -14,38 +14,10 @@
 <div class="c-sidebox">
   <h3 class="c-sidebox__heading">Metrics</h3>
   <div class="o-metrics">
-    <div class="o-metrics__metric">
-      <div class="o-metrics__group">
-        <%= image_tag 'stash_engine/icon_views.svg', class: 'o-metrics__icon', alt: '' %>
-        <!-- <span class="o-metrics__label">views</span> -->
-      </div>
-      <div class="o-metrics__number">
-        <%= @id.counter_stat.unique_investigation_count - @id.counter_stat.unique_request_count %> views
-      </div>
-    </div>
-    <div class="o-metrics__metric">
-      <div class="o-metrics__group">
-        <%= image_tag 'stash_engine/icon_downloads.svg', class: 'o-metrics__icon', alt: '' %>
-        <!-- <span class="o-metrics__label">downloads</span> -->
-      </div>
-      <div class="o-metrics__number"><%= @id.counter_stat.unique_request_count %> downloads</div>
-    </div>
-    <div class="o-metrics__metric">
-      <div class="o-metrics__group">
-        <%= image_tag 'stash_engine/icon_cites.svg', class: 'o-metrics__icon', alt: '' %>
-        <!-- <span class="o-metrics__label">citations</span> -->
-      </div>
-      <div class="o-metrics__number" id="metrics_citation_count">
-        <% if @id.counter_stat.citation_count > 0 %>
-          <%= link_to "#{@id.counter_stat.citation_count} citations", stash_url_helpers.show_citations_path(identifier_id: @id.id),
-                      id: 'citation_link', remote: true %>
-        <% else %>
-          <%= @id.counter_stat.citation_count %> citations
-        <% end %>
-      </div>
-      <div class="o-metrics__number" id="metrics_citation_spinner" style="display: none;">
-        <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
-      </div>
+    <%# render partial: 'stash_engine/landing/metrics', locals: {identifier: @id} %>
+    <div id="show_metrics"
+         data-load="<%= stash_url_helpers.show_metrics_path(identifier_id: @id.id) %>">
+      <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
     </div>
   </div>
 

--- a/stash_engine/app/views/stash_engine/landing/metrics.js.erb
+++ b/stash_engine/app/views/stash_engine/landing/metrics.js.erb
@@ -1,0 +1,2 @@
+$('#show_metrics').html("<%= escape_javascript(
+  render partial: 'stash_engine/landing/metrics', locals: {identifier: @identifier}) %>");

--- a/stash_engine/config/routes.rb
+++ b/stash_engine/config/routes.rb
@@ -70,6 +70,7 @@ StashEngine::Engine.routes.draw do
   get 'dataset/*id', :to => 'landing#show', as: 'show', :constraints => { :id => /\S+/ }
   get 'data_paper/*id', :to => 'landing#data_paper', as: 'data_paper', :constraints => { :id => /\S+/ }
   get 'landing/citations/:identifier_id', to: 'landing#citations', as: 'show_citations'
+  get 'landing/metrics/:identifier_id', to: 'landing#metrics', as: 'show_metrics'
   get '404', :to => 'pages#app_404', as: 'app_404'
 
   patch 'dataset/*id', :to => 'landing#update', :constraints => { :id => /\S+/ }


### PR DESCRIPTION
Our AJAX call to get stats is slow.  Though it is cached for 24 hours, it shouldn't hold the page load up to get the stats because then we're stuck with slowness if we can't get it right away.

This is pretty much a rearrangement / refactoring of existing code and tested on local and dev and it works.