### PR TITLE
Last minute changes to include old_resource_id

### DIFF
--- a/stash_engine/app/serializers/stash_engine/resource_serializer.rb
+++ b/stash_engine/app/serializers/stash_engine/resource_serializer.rb
@@ -32,7 +32,8 @@ module StashEngine
         resource_type: ResourceTypeSerializer.new(@my_model.resource_type).hash,
         rights: @my_model.rights.map { |i| RightSerializer.new(i).hash },
         sizes: @my_model.sizes.map { |i| SizeSerializer.new(i).hash },
-        subjects: @my_model.subjects.order(subject: :asc).map { |i| SubjectSerializer.new(i).hash }
+        subjects: @my_model.subjects.order(subject: :asc).map { |i| SubjectSerializer.new(i).hash },
+        old_resource_id: @my_model.id
       ).merge(tenant_transform)
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/stash_engine/lib/tasks/dash2_migration.rake
+++ b/stash_engine/lib/tasks/dash2_migration.rake
@@ -39,7 +39,7 @@ namespace :dash2_migration do
       next if SKIP_IDENTIFIERS.include?(my_ident.id)
 
       # the following is for testing in development, comment out for all
-      next unless TEST_TENANTS.include?(my_ident.resources.last.tenant_id)
+      # next unless TEST_TENANTS.include?(my_ident.resources.last.tenant_id)
 
       out_array.push(StashEngine::StashIdentifierSerializer.new(my_ident).hash)
     end


### PR DESCRIPTION
This should allow us to import in-progress staged data to the new server by knowing the old and new ids since the directories are named for the IDs.